### PR TITLE
Don't push snupkg separately

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,13 +47,3 @@ jobs:
       nuGetFeedType: external
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master')) 
     displayName: Publish NuGet package
-
-  - task: NuGetCommand@2
-    continueOnError: true
-    inputs:
-      command: push
-      packagesToPush: '$(Build.ArtifactStagingDirectory)\Quamotion.Malaga.*.snupkg'
-      publishFeedCredentials: 'NuGet'
-      nuGetFeedType: external
-    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master')) 
-    displayName: Publish NuGet source package


### PR DESCRIPTION
`nuget push` of a `nupkg` also pushes the `snupkg`, so no need to do that in a separate step.