### PR TITLE
Add GetActiveElement route

### DIFF
--- a/src/Quamotion.Malaga.Tests/MockCommandExecutor.cs
+++ b/src/Quamotion.Malaga.Tests/MockCommandExecutor.cs
@@ -52,6 +52,19 @@ namespace Quamotion.Malaga.Tests
                 };
             }
 
+            if (commandToExecute.Name == WdaDriverCommand.GetActiveElement)
+            {
+                return new Response()
+                {
+                    SessionId = Guid.NewGuid().ToString(),
+                    Status = WebDriverResult.Success,
+                    Value = new Dictionary<string, object>()
+                    {
+                        { "ELEMENT", "56000000 -0000-0000-3A17-000000000000"}
+                    }
+                };
+            }
+
             if (commandToExecute.Name == WdaDriverCommand.GetRectangle)
             {
                 return new Response()

--- a/src/Quamotion.Malaga.Tests/WdaCommandExecutorTests.cs
+++ b/src/Quamotion.Malaga.Tests/WdaCommandExecutorTests.cs
@@ -37,6 +37,7 @@ namespace Quamotion.Malaga.Tests
         [InlineData(WdaDriverCommand.DoubleTap, CommandInfo.PostCommand, "/session/{sessionId}/wda/doubleTap")]
         [InlineData(WdaDriverCommand.WheelSelect, CommandInfo.PostCommand, "/session/{sessionId}/wda/pickerwheel/{elementId}/select")]
         [InlineData(WdaDriverCommand.ForceTouch, CommandInfo.PostCommand, "/session/{sessionId}/wda/element/{elementId}/forceTouch")]
+        [InlineData(WdaDriverCommand.GetActiveElement, CommandInfo.GetCommand, "/session/{sessionId}/element/active")]
         [InlineData("getWindowSize", CommandInfo.GetCommand, "/session/{sessionId}/window/size")]
         [InlineData("sendKeysToActiveElement", CommandInfo.PostCommand, "/session/{sessionId}/wda/keys")]
         public void CommandHandled(string command, string method, string endPoint)

--- a/src/Quamotion.Malaga.Tests/WdaDriverTests.cs
+++ b/src/Quamotion.Malaga.Tests/WdaDriverTests.cs
@@ -49,6 +49,15 @@ namespace Quamotion.Malaga.Tests
         }
 
         [Fact]
+        public void GetActiveElementTest()
+        {
+            var element = this.driver.GetActiveElement();
+            Assert.NotNull(element);
+
+            Assert.Equal("56000000 -0000-0000-3A17-000000000000", this.driver.GetElementId(element));
+        }
+
+        [Fact]
         public void SendKeysTest()
         {
             this.driver.SendKeys("test");

--- a/src/Quamotion.Malaga/WdaCommandExecutor.cs
+++ b/src/Quamotion.Malaga/WdaCommandExecutor.cs
@@ -79,6 +79,8 @@ namespace Quamotion.Malaga
             this.CommandInfoRepository.TryAddCommand(WdaDriverCommand.WheelSelect, new CommandInfo(CommandInfo.PostCommand, "/session/{sessionId}/wda/pickerwheel/{elementId}/select"));
 
             this.CommandInfoRepository.TryAddCommand(WdaDriverCommand.ForceTouch, new CommandInfo(CommandInfo.PostCommand, "/session/{sessionId}/wda/element/{elementId}/forceTouch"));
+
+            this.CommandInfoRepository.TryAddCommand(WdaDriverCommand.GetActiveElement, new CommandInfo(CommandInfo.GetCommand, "/session/{sessionId}/element/active"));
         }
 
         public override Response Execute(Command commandToExecute)

--- a/src/Quamotion.Malaga/WdaDriver.cs
+++ b/src/Quamotion.Malaga/WdaDriver.cs
@@ -90,6 +90,13 @@ namespace Quamotion.Malaga
                 WdaDriverCommand.LaunchApp, parameters);
         }
 
+        public IWebElement GetActiveElement()
+        {
+            var commandResponse = this.Execute(WdaDriverCommand.GetActiveElement, null);
+            var responseValue = commandResponse.Value as Dictionary<string, object>;
+            return new RemoteWebElement(this, responseValue["ELEMENT"].ToString());
+        }
+
         public IWebElement FindElementByClassChain(string classChain)
         {
             return this.FindElement("class chain", classChain);
@@ -547,6 +554,13 @@ namespace Quamotion.Malaga
             return base.CommandExecutor;
         }
 
+        internal string GetElementId(IWebElement webElement)
+        {
+            var remoteWebElementType = typeof(RemoteWebElement);
+            var elementIdField = remoteWebElementType.GetField("elementId", BindingFlags.Instance | BindingFlags.NonPublic);
+            return elementIdField.GetValue(webElement) as string;
+        }
+
         private string GetEnumMemberValue(Enum value)
         {
             var enumMember = value.GetType()
@@ -565,13 +579,6 @@ namespace Quamotion.Malaga
             {
                 return value.ToString();
             }
-        }
-
-        private string GetElementId(IWebElement webElement)
-        {
-            var remoteWebElementType = typeof(RemoteWebElement);
-            var elementIdField = remoteWebElementType.GetField("elementId", BindingFlags.Instance | BindingFlags.NonPublic);
-            return elementIdField.GetValue(webElement) as string;
         }
     }
 }

--- a/src/Quamotion.Malaga/WdaDriverCommand.cs
+++ b/src/Quamotion.Malaga/WdaDriverCommand.cs
@@ -62,5 +62,7 @@
         public const string WheelSelect = "wdaWheelSelect";
 
         public const string ForceTouch = "wdaForceTouch";
+
+        public const string GetActiveElement = "wdaGetActiveElement";
     }
 }


### PR DESCRIPTION
There exists an driver.SwitchTo().ActiveElement() but expects another response. This PR adds a custom command to the WdaDriver to request the active element.